### PR TITLE
Fix parsing of `git` URLs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,8 @@ const parseUrl = require("parse-url")
  *  - `token` (String): The oauth token (could appear in the https urls).
  */
 function gitUp(input) {
-    let output = parseUrl(input);
+    const isInputSsh = isSsh(input);
+    let output = parseUrl(input, !isInputSsh);
     output.token = "";
 
     let splits = output.user.split(":");
@@ -38,7 +39,7 @@ function gitUp(input) {
         }
     }
 
-    if (isSsh(output.protocols) || isSsh(input)) {
+    if (isSsh(output.protocols) || isInputSsh) {
         output.protocol = "ssh";
     } else if (output.protocols.length) {
         output.protocol = output.protocols[0];

--- a/test/index.js
+++ b/test/index.js
@@ -32,6 +32,20 @@ const INPUT = [
           , protocol: "ssh"
         }
     ]
+    , [
+          "git@host.xz:path/name.git"
+        , {
+              protocols: ["git", "ssh"]
+            , protocol: "ssh"
+            , port: null
+            , resource: "host.xz"
+            , user: "git"
+            , pathname: "/path/name.git"
+            , hash: ""
+            , search: ""
+            , protocol: "ssh"
+          }
+      ]
   , [
         "ssh://user@host.xz/path/to/repo.git/"
       , {


### PR DESCRIPTION
Fix #17

Also the unit tests doesn't work. No matters what is set in the `INPUT` the test always pass.
It seems to be due to the `expect` error to be caught and ignore (with just a `debugger` statement).

I tried to fix the test but it seems there is an issue with the test library you are using that throws errors even when two object have the props and values.