### PR TITLE
git-up 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-up",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "A low level git url parser.",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
### `git-up` 6.0.0

:star: This is a major release of `parse-url`! :star:

#### Breaking changes

 - If the input url has a trailing slash, the trailing slash will be added in the `pathname` too.
 - The `port` field is a string. By default empty.
 - Added the `password` field (default: `""`)
 - The resource may contain the `port` in it (e.g. `resource: "domain.com:4200"`).

#### Features

 - Faster
 - More secure
 - Cleaner codebase

