### PR TITLE
fix: adds support for URL-encoded whitespaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/IonicaBizau/git-up",
   "dependencies": {
     "is-ssh": "^1.4.0",
-    "parse-url": "^8.1.0"
+    "parse-url": "^9.2.0"
   },
   "devDependencies": {
     "tester": "^1.4.3"

--- a/test/index.js
+++ b/test/index.js
@@ -34,8 +34,6 @@ const INPUT = [
           , pathname: "/path/name.git"
           , hash: ""
           , search: ""
-          , protocol: "ssh"
-          , password: ""
           , parse_failed: false
         }
     ]
@@ -507,13 +505,27 @@ const INPUT = [
         "git@host.xz:path/name.git"
       , {
             protocols: ["ssh"]
-          , protocol: "ssh"
-          , password: ""
           , port: ""
           , resource: "host.xz"
           , host: "host.xz"
           , user: "git"
           , pathname: "/path/name.git"
+          , hash: ""
+          , search: ""
+          , protocol: "ssh"
+          , password: ""
+          , parse_failed: false
+        }
+    ]
+  , [
+        "git@host.xz:path%20to/repo%20name.git"
+      , {
+            protocols: ["ssh"]
+          , port: ""
+          , resource: "host.xz"
+          , host: "host.xz"
+          , user: "git"
+          , pathname: "/path%20to/repo%20name.git"
           , hash: ""
           , search: ""
           , protocol: "ssh"


### PR DESCRIPTION
v8 of `parse-url` doesn't support URL-encoded whitespaces (i.e.: `%20`).  These are needed for Azure DevOps repositories with spaces in their name (and, likely, others).

Updating to v9 of `parse-url` resolves the issue.

This also includes a small fix to the test file to remove some duplicated properties in an object.

Fixes #36 