### PR TITLE
Bump `parse-url` to v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/IonicaBizau/git-up",
   "dependencies": {
     "is-ssh": "^1.4.0",
-    "parse-url": "^9.2.0"
+    "parse-url": "^10.0.0"
   },
   "devDependencies": {
     "tester": "^1.4.3"


### PR DESCRIPTION
This will drop deprecated `@types/parse-path` from `parse-url`